### PR TITLE
Fix issues relating to character encoding once and for all.

### DIFF
--- a/H2Codez/H2Codez.vcxproj
+++ b/H2Codez/H2Codez.vcxproj
@@ -28,7 +28,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
Debug was set to use `Multi-Byte` and release was set to use `Unicode` this meant that code that worked fine in debug could fail to compile in release and vice-versa. This fixes that by setting both release and debug to `Multi-Byte`.