### PR TITLE
Rename "Open as text" to "Export as test" and cleanup code.

### DIFF
--- a/H2Codez/H2Codez.vcxproj
+++ b/H2Codez/H2Codez.vcxproj
@@ -61,6 +61,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;H2CODEZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4005</DisableSpecificWarnings>
+      <AdditionalOptions>/std:c++14 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -78,6 +79,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;H2CODEZ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>4005</DisableSpecificWarnings>
+      <AdditionalOptions>/std:c++14 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/H2Codez/H2Tool/H2Tool_Commands.h
+++ b/H2Codez/H2Tool/H2Tool_Commands.h
@@ -62,22 +62,22 @@ struct s_file_reference
 }; 
 BOOST_STATIC_ASSERT(sizeof(s_file_reference) == 0x110);
 
-class H2Tool_Extras
+class H2ToolPatches
 {
 public:
-	void Initialize();
-	void AddExtraCommands();
-	void Increase_structure_import_size_Check();
-	void Increase_structure_bsp_geometry_check();
-	void unlock_other_scenario_types_compiling();
-	void enable_campaign_tags_sharing();
-	void apply_shared_tag_removal_scheme();
+	static void Initialize();
+	static void AddExtraCommands();
+	static void Increase_structure_import_size_Check();
+	static void Increase_structure_bsp_geometry_check();
+	static void unlock_other_scenario_types_compiling();
+	static void enable_campaign_tags_sharing();
+	static void apply_shared_tag_removal_scheme();
 
 
 private:
-	void structure_bsp_geometry_2D_check_increase();
-	void structure_bsp_geometry_3D_check_increase();
-	void structure_bsp_geometry_collision_check_increase();
+	static void structure_bsp_geometry_2D_check_increase();
+	static void structure_bsp_geometry_3D_check_increase();
+	static void structure_bsp_geometry_collision_check_increase();
 };
 
 

--- a/H2Codez/H2Tool/H2Tool_extra_commands.inl
+++ b/H2Codez/H2Tool/H2Tool_extra_commands.inl
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <codecvt>
 
 
 //List of extra commands i found are contained here
@@ -52,16 +53,15 @@ static int __cdecl TAG_LOAD(int tag_type, cstring tags_directory, int a3)
 //Finally Sorted out :)
 #pragma endregion 
 
-static DWORD GetH2Tool_Dev__by_name(wcstring function_name)
+static DWORD GetH2Tool_Dev__by_name(wcstring W_function_name)
 {
-	char buffer[_MAX_PATH];
-	wstring_to_string(buffer, sizeof(buffer), function_name, -1);
+	std::string function_name = wstring_to_string.to_bytes(W_function_name);
 	int TABLE_START = 0x97A910;
 	int TABLE_END = 0x97B064;
 	for (;TABLE_START <= TABLE_END;TABLE_START += 0x1C)
 	{
 		cstring command_name = CAST_PTR(cstring, *(DWORD*)TABLE_START);
-		if (strcmp(buffer, command_name) == 0)
+		if (strcmp(function_name.c_str(), command_name) == 0)
 			return TABLE_START;
 
 
@@ -149,10 +149,9 @@ static void _cdecl h2dev_extra_commands_proc(wcstring* arguments)
 			cstring f_name = CAST_PTR(cstring, *(DWORD*)TABLE_START);
 			DWORD f_tag_type =  *(DWORD*)(TABLE_START + 8);
 
-			char f_parameter[MAX_PATH];		
-			wstring_to_string(f_parameter, sizeof(f_parameter), command_parameter_0, -1);
+			std::string f_parameter = wstring_to_string.to_bytes(command_parameter_0);
 			H2PCTool.WriteLog("Tag Type %X \n %s",f_tag_type,f_parameter);			
-			DWORD tag_index = TAG_LOAD(f_tag_type, f_parameter, 7);
+			DWORD tag_index = TAG_LOAD(f_tag_type, f_parameter.c_str(), 7);
 
 			if(((char(__cdecl *)( wchar_t* ,int))*(DWORD*)(TABLE_START+0x18))(0, tag_index))// call Function via address			
 			return;

--- a/H2Codez/H2Tool/LostToolCommands.inl
+++ b/H2Codez/H2Tool/LostToolCommands.inl
@@ -25,14 +25,11 @@ static const s_tool_command* import_class_monitor_structures = CAST_PTR(s_tool_c
 static const s_tool_command* import_class_monitor_bitmaps = CAST_PTR(s_tool_command*, 0x97B594);
 
 
-
+std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_to_string;
 static void _cdecl import_model_proc(wcstring* arguments)
 {
-	wcstring object_name = arguments[0];
+	std::string object_name = wstring_to_string.to_bytes(arguments[0]);
 	wcstring object_type = arguments[1];
-
-	char buffer[_MAX_PATH];
-	wstring_to_string(buffer, sizeof(buffer), object_name, -1);
 
 	static wcstring object_type_names[] = {
 		L"biped",
@@ -67,5 +64,5 @@ static void _cdecl import_model_proc(wcstring* arguments)
 	typedef void (_cdecl* _import_object_model)(cstring object_name, long object_type_mask);
 	static _import_object_model import_object_model = CAST_PTR(_import_object_model, 0x4E7700);
 
-	import_object_model(buffer, object_type_mask);
+	import_object_model(object_name.c_str(), object_type_mask);
 }

--- a/H2Codez/H2Tool_Commands.cpp
+++ b/H2Codez/H2Tool_Commands.cpp
@@ -61,7 +61,7 @@ void _H2ToolDetachHooks()
 	return;
 }
 #pragma region structure_import Tweeks
-void H2Tool_Extras::Increase_structure_import_size_Check()
+void H2ToolPatches::Increase_structure_import_size_Check()
 {
 	//if ( FileSize.LowPart > 0x1400000 && !FileSize.HighPart )
 	 ///1400000h =  20971520 BYTES ~ 20 MB
@@ -82,7 +82,7 @@ void H2Tool_Extras::Increase_structure_import_size_Check()
 	WriteBytesASM(0x41F836+4, Size_Patch, 4);
 
 }
-void H2Tool_Extras::structure_bsp_geometry_collision_check_increase()
+void H2ToolPatches::structure_bsp_geometry_collision_check_increase()
 {
 //return collision_surfaces_count <= 0x7FFF && edges_count <= 0xFFFF && collision_vertices_count <= 0xFFFF;
 	///0x7FFF = 32767
@@ -123,7 +123,7 @@ void H2Tool_Extras::structure_bsp_geometry_collision_check_increase()
 
 
 }
-void H2Tool_Extras::structure_bsp_geometry_3D_check_increase()
+void H2ToolPatches::structure_bsp_geometry_3D_check_increase()
 {
 	// return nodes_count < &unk_800000 && planes_count < 0x8000 && leaves_count < &unk_800000;
 	/// planes_count =0x8000 = 32768 
@@ -140,7 +140,7 @@ void H2Tool_Extras::structure_bsp_geometry_3D_check_increase()
 
 
 }
-void H2Tool_Extras::structure_bsp_geometry_2D_check_increase()
+void H2ToolPatches::structure_bsp_geometry_2D_check_increase()
 {
 /*
 .text:00464BA5 118 push    0        <- b_DONT_CHECK variable is set to false by default .Need to make it true
@@ -153,12 +153,12 @@ void H2Tool_Extras::structure_bsp_geometry_2D_check_increase()
 	//No Need to modify the Proc error here cuz it will never hit :)
 }
 
-void H2Tool_Extras::Increase_structure_bsp_geometry_check()
+void H2ToolPatches::Increase_structure_bsp_geometry_check()
 {
 	H2PCTool.WriteLog("Increasing structure_bsp_geometry checks");
-	this->structure_bsp_geometry_2D_check_increase();
-	this->structure_bsp_geometry_3D_check_increase();
-	this->structure_bsp_geometry_collision_check_increase();
+	structure_bsp_geometry_2D_check_increase();
+	structure_bsp_geometry_3D_check_increase();
+	structure_bsp_geometry_collision_check_increase();
 }
 
 #pragma endregion
@@ -239,7 +239,7 @@ void H2Tool_Extras::Increase_structure_bsp_geometry_check()
 static wcstring k_campaign_shared_name = L"maps\\single_player_shared.map";
 static signed long _scenario_type;
 
-void H2Tool_Extras::apply_shared_tag_removal_scheme()
+void H2ToolPatches::apply_shared_tag_removal_scheme()
 {
 	BYTE* patching_offsets_list[] = {
 		CAST_PTR(BYTE*, 0x5887DF),//_postprocess_animation_data
@@ -258,7 +258,7 @@ void H2Tool_Extras::apply_shared_tag_removal_scheme()
 	for (int x = 0; x < NUMBEROF(patching_offsets_list); x++)			WriteBytesASM((DWORD)(patching_offsets_list[x] + 1), patch, 1);//patching push 1 -> push 0
 }
 
-void H2Tool_Extras::unlock_other_scenario_types_compiling()
+void H2ToolPatches::unlock_other_scenario_types_compiling()
 {
 	//Refer to H2EK_OpenSauce Campaign_sharing
 	static void* BUILD_CACHE_FILE_FOR_SCENARIO__CHECK_SCENARIO_TYPE = CAST_PTR(void*,0x588320);
@@ -310,7 +310,7 @@ static char __cdecl h_BUILD_CACHE_FILE_FOR_SCENARIO__TAG_SHARING_LOAD_SHARED(voi
 
 }
 
-void H2Tool_Extras::enable_campaign_tags_sharing()
+void H2ToolPatches::enable_campaign_tags_sharing()
 {
 	//Refer to H2EK_OpenSauce Campaign_sharing
 
@@ -336,7 +336,7 @@ void H2Tool_Extras::enable_campaign_tags_sharing()
 	H2PCTool.WriteLog("Single Player tag_sharing enabled");
 }
 
-void H2Tool_Extras::Initialize()
+void H2ToolPatches::Initialize()
 {
 	H2PCTool.WriteLog("Dll Successfully Injected to H2Tool");
 	cout << "H2Toolz version " << version << std::endl
@@ -355,7 +355,7 @@ void H2Tool_Extras::Initialize()
 }
 
 
-void H2Tool_Extras::AddExtraCommands()
+void H2ToolPatches::AddExtraCommands()
 {
 	H2PCTool.WriteLog("Adding Extra Commands to H2Tool");
 #pragma region New Function Defination Creation 

--- a/H2Codez/H2ToolsCommon.cpp
+++ b/H2Codez/H2ToolsCommon.cpp
@@ -22,10 +22,19 @@ static const wchar_t *map_types[] =
 	L"Single Player Shared"
 };
 
+static wchar_t const open_as_text[] = L"Export as text";
+
 int WINAPI LoadStringW_Hook(HINSTANCE hInstance, UINT uID, LPWSTR lpBuffer, int cchBufferMax)
 { 
-	if ((310 <= uID && uID <= 318) && (GetModuleHandleW(L"H2alang") == hInstance)) {
+	if (GetModuleHandleW(L"H2alang") != hInstance)
+		return LoadStringW_Orginal(hInstance, uID, lpBuffer, cchBufferMax);
+	if (310 <= uID && uID <= 318) {
 		wcsncpy_s(lpBuffer, cchBufferMax, map_types[uID / 2 - 155], cchBufferMax);
+		return std::wcslen(lpBuffer);
+	}
+	if (uID == 26)
+	{
+		wcsncpy_s(lpBuffer, cchBufferMax, open_as_text, sizeof(open_as_text));
 		return std::wcslen(lpBuffer);
 	}
 	return LoadStringW_Orginal(hInstance, uID, lpBuffer, cchBufferMax);

--- a/H2Codez/h2codez.cpp
+++ b/H2Codez/h2codez.cpp
@@ -4,14 +4,6 @@
 #include "H2ToolsCommon.h"
 #include "DiscordInterface.h"
 
-char* wstring_to_string(char* string, int string_length, wcstring wide, int wide_length)
-{
-	if (!WIN32_FUNC(WideCharToMultiByte)(CP_ACP, 0, wide, wide_length, string, string_length, nullptr, nullptr))
-		return nullptr;
-	else
-		return string;
-}
-
 
 DWORD H2EK_Globals::GetBase()
 {
@@ -54,8 +46,7 @@ bool H2Toolz::Init()
 	switch (game.process_type) {
 	case H2EK::H2Tool:
 	{
-		H2Tool_Extras *tool = new H2Tool_Extras();
-		tool->Initialize();
+		H2ToolPatches::Initialize();
 		return true;
 	}
 	case H2EK::H2Guerilla:

--- a/H2Codez/h2codez.h
+++ b/H2Codez/h2codez.h
@@ -49,7 +49,5 @@ private:
 	static H2EK detect_type();
 };
 
-//as the functions says
-char* wstring_to_string(char* string, int string_length, wcstring wide, int wide_length);
 //eg. {0xFF,0xEE,0xDD,0xCC} ->  {0xCC,0xDD,0xEE,0xFF}
 BYTE* reverse_addr(void* address);


### PR DESCRIPTION
Code Cleanup:
* Make the Class for Tool patches static like the other patch classes
* Use standard C++ functions for converting between wchar_t and char strings
* Tell MSVC to build in C++14 mode.